### PR TITLE
Fix: avoid unnecessary resource updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.5 (December 13, 2021)
+## 2.0.5 (December 17, 2021)
 
 ## Enhancement
 
@@ -11,6 +11,7 @@ The  following policy access resources are supported:
 ## Bug Fixes
 
 - Fixed pagination issues with all resources where only the default pagesize was being returned. [PR#52](https://github.com/willguibr/terraform-provider-zpa/pull/52) :wrench:
+- Fixed issue where Terraform showed that resources had been modified even though nothing had been changed in the upstream resources.[PR#54](https://github.com/willguibr/terraform-provider-zpa/pull/54) :wrench:
 
 ## 2.0.4 (December 6, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
-## 2.0.5 (December 17, 2021)
+## 2.0.5 (December 20, 2021)
 
 ## Enhancement
 
 - The provider now supports the ability to import policy access resources via its `name` and/or `id` property to support easier migration of existing ZPA resources via `terraform import` command.
 The  following policy access resources are supported:
-    - resource_zpa_policy_access_rule - [PR#51](https://github.com/willguibr/terraform-provider-zpa/issues/29)] :rocket:
-    - resource_zpa_policy_access_timeout_rule - [PR#51](https://github.com/willguibr/terraform-provider-zpa/pull/42) :rocket:
-    - resource_zpa_policy_access_forwarding_rule - [PR#51](https://github.com/willguibr/terraform-provider-zpa/pull/42) :rocket:
+    - resource_zpa_policy_access_rule - [PR#51](https://github.com/willguibr/terraform-provider-zpa/issues/51)] :rocket:
+    - resource_zpa_policy_access_timeout_rule - [PR#51](https://github.com/willguibr/terraform-provider-zpa/pull/51) :rocket:
+    - resource_zpa_policy_access_forwarding_rule - [PR#51](https://github.com/willguibr/terraform-provider-zpa/pull/51) :rocket:
+
+- The provider now supports policy access creation to be associated with Cloud Connector Group resource
+    - resource_zpa_policy_access_rule - [PR#54](https://github.com/willguibr/terraform-provider-zpa/pull/54) :rocket:
+
+- Updated the following examples for more accuracy:
+    - resource_zpa_policy_access_rule
+    - resource_zpa_app_connector_group
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The  following policy access resources are supported:
 - The provider now supports policy access creation to be associated with Cloud Connector Group resource
     - resource_zpa_policy_access_rule - [PR#54](https://github.com/willguibr/terraform-provider-zpa/pull/54) :rocket:
 
+- Added new `client_type` to support access, forward, and timeout policy creation. The following new types have been added:
+    - zpn_client_type_ip_anchoring, zpn_client_type_browser_isolation, zpn_client_type_machine_tunnel and zpn_client_type_edge_connector. [PR#57](https://github.com/willguibr/terraform-provider-zpa/issues/57)] :rocket:
+
 - Updated the following examples for more accuracy:
     - resource_zpa_policy_access_rule
     - resource_zpa_app_connector_group

--- a/gozscaler/cloudconnectorgroup/zpa_cloud_connector_group.go
+++ b/gozscaler/cloudconnectorgroup/zpa_cloud_connector_group.go
@@ -42,7 +42,7 @@ type CloudConnectors struct {
 
 func (service *Service) Get(cloudConnectorGroupID string) (*CloudConnectorGroup, *http.Response, error) {
 	v := new(CloudConnectorGroup)
-	relativeURL := fmt.Sprintf(mgmtConfig+service.Client.Config.CustomerID+cloudConnectorGroupEndpoint, cloudConnectorGroupID)
+	relativeURL := mgmtConfig + service.Client.Config.CustomerID + cloudConnectorGroupEndpoint + "/" + cloudConnectorGroupID
 	resp, err := service.Client.NewRequestDo("GET", relativeURL, nil, nil, &v)
 	if err != nil {
 		return nil, nil, err

--- a/gozscaler/common/common.go
+++ b/gozscaler/common/common.go
@@ -7,5 +7,5 @@ const (
 type Pagination struct {
 	PageSize int    `json:"pagesize" url:"pagesize"`
 	Page     int    `json:"page,omitempty" url:"page"`
-	Search   string `json:"search,omitempty" url:"search"`
+	Search   string //`json:"search,omitempty" url:"search"`
 }

--- a/gozscaler/common/common.go
+++ b/gozscaler/common/common.go
@@ -7,5 +7,5 @@ const (
 type Pagination struct {
 	PageSize int    `json:"pagesize" url:"pagesize"`
 	Page     int    `json:"page,omitempty" url:"page"`
-	Search   string //`json:"search,omitempty" url:"search"`
+	Search   string `json:"-" url:"-"`
 }

--- a/zpa/common.go
+++ b/zpa/common.go
@@ -385,6 +385,7 @@ func flattenPolicyRuleOperands(conditionOperand []policysetrule.Operands) []inte
 			"lhs":         operandItems.LHS,
 			"object_type": operandItems.ObjectType,
 			"rhs":         operandItems.RHS,
+			"name":        operandItems.Name,
 		}
 	}
 

--- a/zpa/common.go
+++ b/zpa/common.go
@@ -52,9 +52,9 @@ func validateOperand(operand policysetrule.Operands, zClient *Client) bool {
 			return err
 		}))
 	case "CLIENT_TYPE":
-		return customValidate(operand, []string{"id"}, "'zpn_client_type_zapp' or 'zpn_client_type_exporter'", Getter(func(id string) error {
-			if id != "zpn_client_type_zapp" && id != "zpn_client_type_exporter" {
-				return fmt.Errorf("RHS values must be 'zpn_client_type_zapp' or 'zpn_client_type_exporter' wehn object type is CLIENT_TYPE")
+		return customValidate(operand, []string{"id"}, "'zpn_client_type_zapp' or 'zpn_client_type_exporter' or 'zpn_client_type_ip_anchoring'", Getter(func(id string) error {
+			if id != "zpn_client_type_zapp" && id != "zpn_client_type_exporter" && id != "zpn_client_type_ip_anchoring" {
+				return fmt.Errorf("RHS values must be 'zpn_client_type_zapp' or 'zpn_client_type_exporter' or 'zpn_client_type_ip_anchoring' when object type is CLIENT_TYPE")
 			}
 			return nil
 		}))

--- a/zpa/common.go
+++ b/zpa/common.go
@@ -52,9 +52,9 @@ func validateOperand(operand policysetrule.Operands, zClient *Client) bool {
 			return err
 		}))
 	case "CLIENT_TYPE":
-		return customValidate(operand, []string{"id"}, "'zpn_client_type_zapp' or 'zpn_client_type_exporter' or 'zpn_client_type_ip_anchoring'", Getter(func(id string) error {
-			if id != "zpn_client_type_zapp" && id != "zpn_client_type_exporter" && id != "zpn_client_type_ip_anchoring" {
-				return fmt.Errorf("RHS values must be 'zpn_client_type_zapp' or 'zpn_client_type_exporter' or 'zpn_client_type_ip_anchoring' when object type is CLIENT_TYPE")
+		return customValidate(operand, []string{"id"}, "'zpn_client_type_zapp' or 'zpn_client_type_exporter' or 'zpn_client_type_ip_anchoring' or 'zpn_client_type_browser_isolation' or 'zpn_client_type_machine_tunnel' or 'zpn_client_type_edge_connector'", Getter(func(id string) error {
+			if id != "zpn_client_type_zapp" && id != "zpn_client_type_exporter" && id != "zpn_client_type_ip_anchoring" && id != "zpn_client_type_browser_isolation" && id != "zpn_client_type_machine_tunnel" && id != "zpn_client_type_edge_connector" {
+				return fmt.Errorf("RHS values must be 'zpn_client_type_zapp' or 'zpn_client_type_exporter' or 'zpn_client_type_ip_anchoring' or 'zpn_client_type_browser_isolation' or 'zpn_client_type_machine_tunnel' or 'zpn_client_type_edge_connector' when object type is CLIENT_TYPE")
 			}
 			return nil
 		}))

--- a/zpa/common.go
+++ b/zpa/common.go
@@ -46,7 +46,7 @@ func validateOperand(operand policysetrule.Operands, zClient *Client) bool {
 			_, _, err := zClient.idpcontroller.Get(id)
 			return err
 		}))
-	case "CLOUD_CONNECTOR_GROUP":
+	case "EDGE_CONNECTOR_GROUP":
 		return customValidate(operand, []string{"id"}, "cloud connector group ID", Getter(func(id string) error {
 			_, _, err := zClient.cloudconnectorgroup.Get(id)
 			return err

--- a/zpa/common.go
+++ b/zpa/common.go
@@ -424,6 +424,7 @@ func CommonPolicySchema() map[string]*schema.Schema {
 		"operator": {
 			Type:     schema.TypeString,
 			Optional: true,
+			Computed: true,
 			ValidateFunc: validation.StringInSlice([]string{
 				"AND",
 				"OR",
@@ -436,10 +437,12 @@ func CommonPolicySchema() map[string]*schema.Schema {
 		"policy_type": {
 			Type:     schema.TypeString,
 			Optional: true,
+			Computed: true,
 		},
 		"priority": {
 			Type:     schema.TypeString,
 			Optional: true,
+			Computed: true,
 		},
 		"reauth_default_rule": {
 			Type:     schema.TypeBool,
@@ -456,6 +459,7 @@ func CommonPolicySchema() map[string]*schema.Schema {
 		"rule_order": {
 			Type:     schema.TypeString,
 			Optional: true,
+			Computed: true,
 		},
 		"lss_default_rule": {
 			Type:     schema.TypeBool,
@@ -520,6 +524,7 @@ func resourceAppSegmentPortRange(desc string) *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeSet,
 		Optional:    true,
+		Computed:    true,
 		Description: desc,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{

--- a/zpa/common.go
+++ b/zpa/common.go
@@ -218,6 +218,7 @@ func GetPolicyConditionsSchema(objectTypes []string) *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
+		Computed:    true,
 		Description: "This is for proviidng the set of conditions for the policy.",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -228,6 +229,7 @@ func GetPolicyConditionsSchema(objectTypes []string) *schema.Schema {
 				"negated": {
 					Type:     schema.TypeBool,
 					Optional: true,
+					Computed: true,
 				},
 				"operator": {
 					Type:     schema.TypeString,
@@ -240,6 +242,7 @@ func GetPolicyConditionsSchema(objectTypes []string) *schema.Schema {
 				"operands": {
 					Type:        schema.TypeList,
 					Optional:    true,
+					Computed:    true,
 					Description: "This signifies the various policy criteria.",
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
@@ -250,10 +253,12 @@ func GetPolicyConditionsSchema(objectTypes []string) *schema.Schema {
 							"idp_id": {
 								Type:     schema.TypeString,
 								Optional: true,
+								Computed: true,
 							},
 							"name": {
 								Type:     schema.TypeString,
 								Optional: true,
+								Computed: true,
 							},
 							"lhs": {
 								Type:        schema.TypeString,

--- a/zpa/data_source_zpa_cloud_connector_group.go
+++ b/zpa/data_source_zpa_cloud_connector_group.go
@@ -46,7 +46,8 @@ func dataSourceCloudConnectorGroup() *schema.Resource {
 							Computed: true,
 						},
 						"ipacl": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeList,
+							Elem:     schema.TypeString,
 							Computed: true,
 						},
 						"issued_cert_id": {

--- a/zpa/data_source_zpa_cloud_connector_group.go
+++ b/zpa/data_source_zpa_cloud_connector_group.go
@@ -13,7 +13,7 @@ func dataSourceCloudConnectorGroup() *schema.Resource {
 		Read: dataSourceCloudConnectorGroupRead,
 		Schema: map[string]*schema.Schema{
 			"creation_time": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"description": {
@@ -26,7 +26,7 @@ func dataSourceCloudConnectorGroup() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"creation_time": {
-							Type:     schema.TypeInt,
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"description": {
@@ -42,7 +42,7 @@ func dataSourceCloudConnectorGroup() *schema.Resource {
 							Computed: true,
 						},
 						"id": {
-							Type:     schema.TypeInt,
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"ipacl": {
@@ -50,15 +50,15 @@ func dataSourceCloudConnectorGroup() *schema.Resource {
 							Computed: true,
 						},
 						"issued_cert_id": {
-							Type:     schema.TypeInt,
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"modifiedby": {
-							Type:     schema.TypeInt,
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"modified_time": {
-							Type:     schema.TypeInt,
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"name": {
@@ -78,7 +78,7 @@ func dataSourceCloudConnectorGroup() *schema.Resource {
 				Computed: true,
 			},
 			"geolocation_id": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"id": {
@@ -86,11 +86,11 @@ func dataSourceCloudConnectorGroup() *schema.Resource {
 				Optional: true,
 			},
 			"modifiedby": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"modified_time": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"name": {
@@ -102,7 +102,7 @@ func dataSourceCloudConnectorGroup() *schema.Resource {
 				Computed: true,
 			},
 			"zia_org_id": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},

--- a/zpa/data_source_zpa_lss_config_log_types_formats.go
+++ b/zpa/data_source_zpa_lss_config_log_types_formats.go
@@ -23,6 +23,7 @@ func dataSourceLSSLotTypeFormats() *schema.Resource {
 					"zpn_ast_auth_log",
 					"zpn_http_trans_log",
 					"zpn_audit_log",
+					"zpn_ast_comprehensive_stats",
 				}, false),
 			},
 			"tsv": {

--- a/zpa/resource_zpa_app_connector_group.go
+++ b/zpa/resource_zpa_app_connector_group.go
@@ -101,6 +101,7 @@ func resourceAppConnectorGroup() *schema.Resource {
 			"lss_app_connector_group": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 			"upgrade_day": {
 				Type:        schema.TypeString,
@@ -132,7 +133,8 @@ func resourceAppConnectorGroup() *schema.Resource {
 			"version_profile_name": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "Default",
+				//Default:  "Default",
+				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"Default", "Previous Default", "New Release",
 				}, false),
@@ -181,7 +183,7 @@ func resourceAppConnectorGroupRead(d *schema.ResourceData, m interface{}) error 
 	_ = d.Set("latitude", resp.Latitude)
 	_ = d.Set("longitude", resp.Longitude)
 	_ = d.Set("location", resp.Location)
-	_ = d.Set("lss_app_connector_group", resp.LSSAppConnectorGroup)
+	//_ = d.Set("lss_app_connector_group", resp.LSSAppConnectorGroup)
 	_ = d.Set("upgrade_day", resp.UpgradeDay)
 	_ = d.Set("upgrade_time_in_secs", resp.UpgradeTimeInSecs)
 	_ = d.Set("override_version_profile", resp.OverrideVersionProfile)

--- a/zpa/resource_zpa_app_connector_group.go
+++ b/zpa/resource_zpa_app_connector_group.go
@@ -51,7 +51,6 @@ func resourceAppConnectorGroup() *schema.Resource {
 			},
 			"city_country": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"country_code": {
@@ -125,19 +124,14 @@ func resourceAppConnectorGroup() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "ID of the version profile. To learn more, see Version Profile Use Cases. This value is required, if the value for overrideVersionProfile is set to true",
-				Default:     0,
+				Default:     "0",
 				ValidateFunc: validation.StringInSlice([]string{
 					"0", "1", "2",
 				}, false),
 			},
 			"version_profile_name": {
 				Type:     schema.TypeString,
-				Optional: true,
-				//Default:  "Default",
 				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"Default", "Previous Default", "New Release",
-				}, false),
 			},
 		},
 	}

--- a/zpa/resource_zpa_app_connector_group.go
+++ b/zpa/resource_zpa_app_connector_group.go
@@ -52,10 +52,12 @@ func resourceAppConnectorGroup() *schema.Resource {
 			"city_country": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"country_code": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"description": {
 				Type:        schema.TypeString,

--- a/zpa/resource_zpa_app_server_controller.go
+++ b/zpa/resource_zpa_app_server_controller.go
@@ -61,11 +61,13 @@ func resourceApplicationServer() *schema.Resource {
 			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				Description: "This field defines the status of the server.",
 			},
 			// App Server Group ID can only be attached if Dynamic Server Discovery in Server Group is False
 			"app_server_group_ids": {
 				Type:        schema.TypeSet,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "This field defines the list of server groups IDs.",
 				Optional:    true,

--- a/zpa/resource_zpa_application_segment.go
+++ b/zpa/resource_zpa_application_segment.go
@@ -53,6 +53,7 @@ func resourceApplicationSegment() *schema.Resource {
 			"bypass_type": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "Indicates whether users can bypass ZPA to access applications.",
 				ValidateFunc: validation.StringInSlice([]string{
 					"ALWAYS",
@@ -66,6 +67,7 @@ func resourceApplicationSegment() *schema.Resource {
 			"tcp_port_ranges": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Deprecated:  "The tcp_port_ranges and udp_port_ranges fields are deprecated and replaced with tcp_port_range and udp_port_range.",
 				Description: "TCP port ranges used to access the app.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -73,6 +75,7 @@ func resourceApplicationSegment() *schema.Resource {
 			"udp_port_ranges": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Deprecated:  "The tcp_port_ranges and udp_port_ranges fields are deprecated and replaced with tcp_port_range and udp_port_range.",
 				Description: "UDP port ranges used to access the app.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -276,7 +279,7 @@ func resourceApplicationSegmentRead(d *schema.ResourceData, m interface{}) error
 		return err
 	}
 
-	if err := d.Set("tcp_port_range", flattenAppSegmentPortRange(resp.UDPAppPortRange)); err != nil {
+	if err := d.Set("udp_port_range", flattenAppSegmentPortRange(resp.UDPAppPortRange)); err != nil {
 		return err
 	}
 

--- a/zpa/resource_zpa_application_segment.go
+++ b/zpa/resource_zpa_application_segment.go
@@ -95,7 +95,7 @@ func resourceApplicationSegment() *schema.Resource {
 				Description: "Description of the application.",
 			},
 			"domain_names": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Required:    true,
 				Description: "List of domains and IPs.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -376,7 +376,7 @@ func expandApplicationSegmentRequest(d *schema.ResourceData) applicationsegment.
 		PassiveHealthEnabled: d.Get("passive_health_enabled").(bool),
 		IcmpAccessType:       d.Get("icmp_access_type").(string),
 		Description:          d.Get("description").(string),
-		DomainNames:          expandStringInSlice(d, "domain_names"),
+		DomainNames:          SetToStringList(d, "domain_names"),
 		DoubleEncrypt:        d.Get("double_encrypt").(bool),
 		Enabled:              d.Get("enabled").(bool),
 		HealthReporting:      d.Get("health_reporting").(string),

--- a/zpa/resource_zpa_browser_access.go
+++ b/zpa/resource_zpa_browser_access.go
@@ -52,6 +52,7 @@ func resourceBrowserAccess() *schema.Resource {
 			"segment_group_name": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"bypass_type": {
 				Type:        schema.TypeString,
@@ -70,6 +71,7 @@ func resourceBrowserAccess() *schema.Resource {
 			"tcp_port_ranges": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Deprecated:  "The tcp_port_ranges and udp_port_ranges fields are deprecated and replaced with tcp_port_range and udp_port_range.",
 				Description: "TCP port ranges used to access the app.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -77,6 +79,7 @@ func resourceBrowserAccess() *schema.Resource {
 			"udp_port_ranges": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Deprecated:  "The tcp_port_ranges and udp_port_ranges fields are deprecated and replaced with tcp_port_range and udp_port_range.",
 				Description: "UDP port ranges used to access the app.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -105,6 +108,7 @@ func resourceBrowserAccess() *schema.Resource {
 			"health_check_type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"passive_health_enabled": {
 				Type:     schema.TypeBool,
@@ -113,10 +117,12 @@ func resourceBrowserAccess() *schema.Resource {
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 			"health_reporting": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "Whether health reporting for the app is Continuous or On Access. Supported values: NONE, ON_ACCESS, CONTINUOUS.",
 			},
 			"ip_anchored": {
@@ -297,7 +303,7 @@ func resourceBrowserAccessRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	if err := d.Set("tcp_port_range", flattenNetworkPorts(resp.UDPAppPortRange)); err != nil {
+	if err := d.Set("udp_port_range", flattenNetworkPorts(resp.UDPAppPortRange)); err != nil {
 		return err
 	}
 

--- a/zpa/resource_zpa_browser_access.go
+++ b/zpa/resource_zpa_browser_access.go
@@ -113,6 +113,7 @@ func resourceBrowserAccess() *schema.Resource {
 			"passive_health_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 			"enabled": {
 				Type:     schema.TypeBool,
@@ -155,6 +156,7 @@ func resourceBrowserAccess() *schema.Resource {
 						"application_port": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"application_protocol": {
 							Type:     schema.TypeString,
@@ -173,10 +175,12 @@ func resourceBrowserAccess() *schema.Resource {
 						"certificate_name": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"cname": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"description": {
 							Type:     schema.TypeString,
@@ -189,10 +193,12 @@ func resourceBrowserAccess() *schema.Resource {
 						"enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 						"hidden": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 						"id": {
 							Type:     schema.TypeString,
@@ -213,6 +219,7 @@ func resourceBrowserAccess() *schema.Resource {
 						"trust_untrusted_cert": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},

--- a/zpa/resource_zpa_lss_config_controller.go
+++ b/zpa/resource_zpa_lss_config_controller.go
@@ -198,6 +198,7 @@ func resourceLSSConfigController() *schema.Resource {
 								"zpn_audit_log",
 								"zpn_sys_auth_log",
 								"zpn_http_insp",
+								"zpn_ast_comprehensive_stats",
 							}, false),
 						},
 						"use_tls": {

--- a/zpa/resource_zpa_policy_access_rule.go
+++ b/zpa/resource_zpa_policy_access_rule.go
@@ -44,6 +44,7 @@ func resourcePolicyAccessRule() *schema.Resource {
 				"app_server_groups": {
 					Type:        schema.TypeSet,
 					Optional:    true,
+					Computed:    true,
 					Description: "List of the server group IDs.",
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
@@ -60,6 +61,7 @@ func resourcePolicyAccessRule() *schema.Resource {
 				"app_connector_groups": {
 					Type:        schema.TypeSet,
 					Optional:    true,
+					Computed:    true,
 					Description: "List of app-connector IDs.",
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{

--- a/zpa/resource_zpa_segment_group.go
+++ b/zpa/resource_zpa_segment_group.go
@@ -132,7 +132,7 @@ func resourceSegmentGroupRead(d *schema.ResourceData, m interface{}) error {
 	_ = d.Set("description", resp.Description)
 	_ = d.Set("enabled", resp.Enabled)
 	_ = d.Set("name", resp.Name)
-	_ = d.Set("policy_migrated", resp.PolicyMigrated)
+	//_ = d.Set("policy_migrated", resp.PolicyMigrated)
 	_ = d.Set("tcp_keep_alive_enabled", resp.TcpKeepAliveEnabled)
 	if err := d.Set("applications", flattenSegmentGroupApplicationsSimple(resp)); err != nil {
 		return fmt.Errorf("failed to read applications %s", err)

--- a/zpa/resource_zpa_server_group.go
+++ b/zpa/resource_zpa_server_group.go
@@ -80,6 +80,7 @@ func resourceServerGroup() *schema.Resource {
 			"servers": {
 				Type:        schema.TypeSet,
 				Optional:    true,
+				Computed:    true,
 				Description: "This field is a list of servers that are applicable only when dynamic discovery is disabled. Server name is required only in cases where the new servers need to be created in this API. For existing servers, pass only the serverId.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -96,6 +97,7 @@ func resourceServerGroup() *schema.Resource {
 			"applications": {
 				Type:        schema.TypeSet,
 				Optional:    true,
+				Computed:    true,
 				Description: "This field is a json array of app-connector-id only.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -112,6 +114,7 @@ func resourceServerGroup() *schema.Resource {
 			"app_connector_groups": {
 				Type:        schema.TypeSet,
 				Optional:    true,
+				Computed:    true,
 				Description: "List of app-connector IDs.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/zpa/resource_zpa_service_edge_group.go
+++ b/zpa/resource_zpa_service_edge_group.go
@@ -51,10 +51,12 @@ func resourceServiceEdgeGroup() *schema.Resource {
 			"city_country": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"country_code": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"description": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
ThIs PR avoids unnecessary resource updates when you run TF apply without any changes on the local/remote config.
Mainly the unnecessary updates happens when a param `X=null` is Optional but the API have a default value for it `X=D`. TF will detect on the next apply that X is not in sync with the remote config `X(remote)=D != X(local)=null` so it will try to update it.