### PR TITLE
Accelerate zpa_policy_access_rule resource

### DIFF
--- a/zpa/resource_zpa_policy_access_rule.go
+++ b/zpa/resource_zpa_policy_access_rule.go
@@ -123,7 +123,7 @@ func resourcePolicyAccessCreate(d *schema.ResourceData, m interface{}) error {
 func resourcePolicyAccessRead(d *schema.ResourceData, m interface{}) error {
 	zClient := m.(*Client)
 
-	globalPolicySet, _, err := zClient.policysetcontroller.GetPolicySet()
+	globalPolicySet, _, err := zClient.policysetcontroller.GetByPolicyType("ACCESS_POLICY")
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func resourcePolicyAccessRead(d *schema.ResourceData, m interface{}) error {
 
 func resourcePolicyAccessUpdate(d *schema.ResourceData, m interface{}) error {
 	zClient := m.(*Client)
-	globalPolicySet, _, err := zClient.policysetcontroller.GetPolicySet()
+	globalPolicySet, _, err := zClient.policysetcontroller.GetByPolicyType("ACCESS_POLICY")
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func resourcePolicyAccessUpdate(d *schema.ResourceData, m interface{}) error {
 
 func resourcePolicyAccessDelete(d *schema.ResourceData, m interface{}) error {
 	zClient := m.(*Client)
-	globalPolicySet, _, err := zClient.policysetcontroller.GetPolicySet()
+	globalPolicySet, _, err := zClient.policysetcontroller.GetByPolicyType("ACCESS_POLICY")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

* Accelerate performance of zpa_policy_access_rule refresh by switching
  from the deprecated policySet/global endpoint to the new
  policySet/policyType/ACCESS_POLICY endpoint.

## Motivation and Context

We noticed that refreshing long sets of zpa_policy_access_rule resources was *slow*.
With this patch, the time take to plan a module managing 148 app segments, 79 segment groups, 91 policy access rules and 68 SCIM groups, is reduced from 4m04s to 3m30s.

## How Has This Been Tested?

Tested against a complex production instance of Zscaler.
```
No changes. Your infrastructure matches the configuration.
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
