### PR TITLE
Support explicitly empty port ranges

### DIFF
--- a/zpa/common.go
+++ b/zpa/common.go
@@ -528,9 +528,11 @@ func expandNetwokPorts(d *schema.ResourceData, key string) []common.NetworkPorts
 
 func resourceAppSegmentPortRange(desc string) *schema.Schema {
 	return &schema.Schema{
-		Type:        schema.TypeSet,
-		Optional:    true,
-		Computed:    true,
+		Type:     schema.TypeSet,
+		Optional: true,
+		Computed: true,
+		// Activate the "Attributes as Blocks" processing mode to permit dynamic declaration of no ports
+		ConfigMode:  schema.SchemaConfigModeAttr,
 		Description: desc,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{


### PR DESCRIPTION
## Description

Allow optional use of [Attributes as Blocks](https://www.terraform.io/language/attr-as-blocks) syntax for `zpa_application_segment`'s `{tcp,udp}_port_range` blocks, allowing clean specification of "no port ranges" in dynamic contexts.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The modern `{tcp,udp}_port_range` syntax is preferred, but with both `{tcp,udp}_port_range` blocks and legacy `{tcp,udp}_port_ranges` attr marked `Computed: true`, it is not currently possible to explicitly declare that *no* port ranges should be configured for a given Application Segment, without kludgily mixing both syntax styles.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested against production Zscaler instance.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Example usage:

```hcl
resource "application_segment" "map" {
  for_each = local.app_segments

  ...elided...

  tcp_port_range = [
    for tcp_port_range in [
      for item in try(
        flatten([for raw_item in each.value.tcp_ports : try(local.services[raw_item].tcp_ports, raw_item)]),
        []
      ) :
      regex(
        "^(?P<from>[[:digit:]]+)(?:-(?P<to>[[:digit:]]+))?$",
        item
      )
    ] :
    {
      from = tcp_port_range.from
      to   = coalesce(tcp_port_range.to, tcp_port_range.from)
    }
  ]
```

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
